### PR TITLE
Added ldap_initialize

### DIFF
--- a/source/dldap/c/ldap_h.d
+++ b/source/dldap/c/ldap_h.d
@@ -14,6 +14,7 @@ extern(C):
 
 // Init
 ldap* ldap_init (const char* host, int port);
+int ldap_initialize (ldap** ldp, const char* uri);
 
 // Bind -- deprecated. TODO: ldap_sasl_bind(_s)
 int ldap_bind(ldap *ld, const char* dn, const char* passwd, int authmethod);

--- a/source/dldap/connection.d
+++ b/source/dldap/connection.d
@@ -40,6 +40,11 @@ class LDAPConnection
 		ldap* ld;
 	}
 
+	this(const string uri)
+	{
+		ldap_initialize(&ld, uri.cString);
+	}
+
 	this(const string host, const ushort port)
 	{
 		ld = ldap_init(host.cString, port);


### PR DESCRIPTION
This is a request to use LDAP over SSL (e.g., ldaps://).

**usage example:**
`auto ldap = new LDAPConnection("ldaps://ldap.example.com");`
